### PR TITLE
Rename write file function

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm run bin <path>
 import {
   fileToBinaryString,
   fileToFfxScript,
-  writeBinaryStringToTxt,
+  writeBinaryStringToFile,
 } from "ffx-to-js";
 
 // Returns binary string
@@ -41,7 +41,7 @@ const binary = await fileToBinaryString("./preset.ffx");
 const script = await fileToFfxScript("./preset.ffx");
 
 // Saves JS code as file
-await writeBinaryStringToTxt("./preset.ffx", "./preset.js");
+await writeBinaryStringToFile("./preset.ffx", "./preset.js");
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ffx-to-js
 
-Convert a binary file (e.g. After Effects `.ffx`) into a JS-escaped binary string,
-optionally wrapped in an ExtendScript helper to recreate the file.
+Convert an After Effects `.ffx` file into a JS-escaped binary string, optionally wrapped in an ExtendScript helper to recreate the file.
 
 ## CLI
 
@@ -35,8 +34,13 @@ import {
   writeBinaryStringToTxt,
 } from "ffx-to-js";
 
+// Returns binary string
 const binary = await fileToBinaryString("./preset.ffx");
+
+// Returns full JS code (binary string + script)
 const script = await fileToFfxScript("./preset.ffx");
+
+// Saves JS code as file
 await writeBinaryStringToTxt("./preset.ffx", "./preset.js");
 ```
 

--- a/bin.ts
+++ b/bin.ts
@@ -3,7 +3,7 @@ import { writeFile } from "node:fs/promises";
 import {
   defaultOutputPathForInput,
   fileToBinaryString,
-  writeBinaryStringToTxt,
+  writeBinaryStringToFile,
 } from "./index.js";
 
 const args = process.argv.slice(2);
@@ -67,7 +67,7 @@ const run = async () => {
     return;
   }
 
-  const writtenPath = await writeBinaryStringToTxt(inputPath, resolvedOutput, {
+  const writtenPath = await writeBinaryStringToFile(inputPath, resolvedOutput, {
     varName,
     fileName,
     resourceFolder,

--- a/index.ts
+++ b/index.ts
@@ -126,7 +126,7 @@ export async function fileToFfxScript(
   });
 }
 
-export async function writeBinaryStringToTxt(
+export async function writeBinaryStringToFile(
   inputPath: string,
   outputPath?: string,
   options: FfxScriptOptions = {},


### PR DESCRIPTION
Rename the file-writing function from `writeBinaryStringToTxt` to `writeBinaryStringToFile`.

This change fixes the misleading `.txt` implication in the function name and improves overall semantics.