### PR TITLE
Restrict input to .ffx files only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ffx-to-js
 
-Convert a binary file (e.g. After Effects `.ffx`) into a JS-escaped binary string,
-optionally wrapped in an ExtendScript helper to recreate the file.
+Convert an After Effects `.ffx` file into a JS-escaped binary string, optionally wrapped in an ExtendScript helper to recreate the file.
 
 ## CLI
 
@@ -35,8 +34,13 @@ import {
   writeBinaryStringToTxt,
 } from "ffx-to-js";
 
+// Returns binary string
 const binary = await fileToBinaryString("./preset.ffx");
+
+// Returns full JS code (binary string + script)
 const script = await fileToFfxScript("./preset.ffx");
+
+// Saves JS code as file
 await writeBinaryStringToTxt("./preset.ffx", "./preset.js");
 ```
 

--- a/bin.ts
+++ b/bin.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { writeFile } from "node:fs/promises";
+import path from "node:path";
 import {
   defaultOutputPathForInput,
   fileToBinaryString,
@@ -23,6 +24,14 @@ if (!inputPath || inputPath === "-h" || inputPath === "--help") {
     ].join("\n"),
   );
   process.exit(inputPath ? 0 : 1);
+}
+
+const inputExt = path.extname(inputPath).toLowerCase();
+if (inputExt !== ".ffx") {
+  console.error(
+    `Error: Input file must be a .ffx file, got "${inputExt || "(no extension)"}".`,
+  );
+  process.exit(1);
 }
 
 let outputPath: string | undefined;


### PR DESCRIPTION
## Summary

- Adds validation to ensure only `.ffx` files are accepted as input
- Throws a clear error message and exits with code 1 for non-.ffx files
- Handles edge case of files with no extension

Closes #1